### PR TITLE
[Storage] Move to MMKVManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "author": "Beef",
     "license": "BSD-3-Clause",
     "devDependencies": {
-        "@react-native-async-storage/async-storage": "^1.17.11",
         "@types/react": "18.0.26",
         "@types/react-native": "0.68.1",
         "esbuild": "^0.16.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,6 @@ overrides:
   '@types/react': 18.0.26
 
 specifiers:
-  '@react-native-async-storage/async-storage': ^1.17.11
   '@types/react': 18.0.26
   '@types/react-native': 0.68.1
   esbuild: ^0.16.17
@@ -18,7 +17,6 @@ dependencies:
   spitroast: 1.4.2
 
 devDependencies:
-  '@react-native-async-storage/async-storage': 1.17.11
   '@types/react': 18.0.26
   '@types/react-native': 0.68.1
   esbuild: 0.16.17
@@ -227,17 +225,6 @@ packages:
     dev: true
     optional: true
 
-  /@react-native-async-storage/async-storage/1.17.11:
-    resolution: {integrity: sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==}
-    peerDependencies:
-      react-native: ^0.0.0-0 || 0.60 - 0.71 || 1000.0.0
-    peerDependenciesMeta:
-      react-native:
-        optional: true
-    dependencies:
-      merge-options: 3.0.4
-    dev: true
-
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
@@ -308,22 +295,10 @@ packages:
       '@esbuild/win32-x64': 0.16.17
     dev: true
 
-  /is-plain-obj/2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
-    dev: true
-
   /magic-string/0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: true
-
-  /merge-options/3.0.4:
-    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      is-plain-obj: 2.1.0
     dev: true
 
   /sourcemap-codec/1.4.8:

--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -1,7 +1,6 @@
 import * as _spitroast from "spitroast";
 import _React from "react";
 import _RN from "react-native";
-import _AsyncStorage from "@react-native-async-storage/async-storage";
 
 type MetroModules = { [id: number]: any };
 
@@ -104,7 +103,6 @@ interface VendettaObject {
             toasts: PropIntellisense<"open" | "close">;
             React: typeof _React;
             ReactNative: typeof _RN;
-            AsyncStorage: typeof _AsyncStorage;
         };
     };
     constants: {

--- a/src/lib/metro/common.ts
+++ b/src/lib/metro/common.ts
@@ -18,8 +18,5 @@ export const Flux = findByProps("connectStores");
 export const FluxDispatcher = findByProps("_currentDispatchActionType");
 
 // React
-export const React = findByProps("createElement") as typeof import("react");
-export const ReactNative = findByProps("Text", "Image") as typeof import("react-native");
-
-// AsyncStorage
-export const AsyncStorage = findByProps("setItem") as typeof import("@react-native-async-storage/async-storage").default;
+export const React = window.React as typeof import("react");
+export { ReactNative } from "@metro/hoist";

--- a/src/lib/metro/filters.ts
+++ b/src/lib/metro/filters.ts
@@ -1,4 +1,5 @@
 import { MetroModules, PropsFinder, PropsFinderAll } from "@types";
+import { moment } from "@metro/hoist";
 
 // Metro require
 declare const __r: (moduleId: number) => any;
@@ -23,15 +24,6 @@ for (const key in window.modules) {
         continue;
     }
 }
-
-// Early find logic
-const basicFind = (prop: string) => Object.values(window.modules).find(m => m.publicModule.exports?.[prop]).publicModule.exports;
-
-// Hoist React
-window.React = basicFind("createElement");
-
-// Find moment
-let moment = basicFind("isMoment");
 
 // Function to filter through modules
 export const filterModules = (modules: MetroModules, single = false) => (filter: (m: any) => boolean) => {

--- a/src/lib/metro/hoist.ts
+++ b/src/lib/metro/hoist.ts
@@ -1,0 +1,14 @@
+// Hoist required modules
+// This used to be in filters.ts, but things became convoluted
+
+// Early find logic
+const basicFind = (prop: string) => Object.values(window.modules).find(m => m.publicModule.exports?.[prop]).publicModule.exports;
+
+// Hoist React on window
+window.React = basicFind("createElement") as typeof import("react");;
+
+// Export ReactNative
+export const ReactNative = basicFind("Text") as typeof import("react-native");
+
+// Export moment
+export const moment = basicFind("isMoment");

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,9 @@
 import { Indexable } from "@types";
-import { AsyncStorage } from "@metro/common";
+import { ReactNative as RN } from "@metro/hoist";
+
+// Discord's custom special storage sauce
+// TODO: Type this
+const MMKVManager = RN.NativeModules.MMKVManager;
 
 // TODO: React hook?
 // TODO: Clean up types, if necessary
@@ -19,18 +23,18 @@ export default function createStorage<T>(storeName: string, onRestore?: (parsed:
     
         set(target: object, key: string | symbol, value: any) {
             Reflect.set(target, key, value);
-            AsyncStorage.setItem(storeName, JSON.stringify(internalStore));
+            MMKVManager.setItem(storeName, JSON.stringify(internalStore));
             return true;
         },
     
         deleteProperty(target: object, key: string | symbol) {
             Reflect.deleteProperty(target, key);
-            AsyncStorage.setItem(storeName, JSON.stringify(internalStore));
+            MMKVManager.setItem(storeName, JSON.stringify(internalStore));
             return true;
         }
     }
 
-    AsyncStorage.getItem(storeName).then(async function (v) {
+    MMKVManager.getItem(storeName).then(async function (v: any) {
         if (!v) return;
         const parsed: T & Indexable<any> = JSON.parse(v);
 


### PR DESCRIPTION
It has been brought to attention that when Discord upgrade their React Native version to 0.71 (they are currently on 0.68), AsyncStorage will be removed, breaking Vendetta. There are several other issues with AsyncStorage such as reliability and speed, so this PR proposes the move to MMKVManager, a native module Discord provide.

I have currently tested this on Android, where it works flawlessly, but I need someone to test this on iOS before I merge it. As such, it is marked as a draft.