### PR TITLE
Don't import Events in def.d.ts

### DIFF
--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -1,7 +1,6 @@
 import * as _spitroast from "spitroast";
 import _React from "react";
 import _RN from "react-native";
-import { Events } from "@lib/emitter";
 
 type MetroModules = { [id: number]: any };
 
@@ -178,7 +177,7 @@ interface MMKVManager {
 
 type Indexable<Type> = { [index: string]: Type }
 
-type EmitterEvent = (keyof typeof Events) & string;
+type EmitterEvent = "SET" | "GET" | "DEL";
 
 interface EmitterListenerData {
 	path: string[];


### PR DESCRIPTION
Importing something that isn't a type is a bad idea and doesn't work well with the upcoming method of vendetta-types generation.