### PR TITLE
[Plugins] Give plugins their own logger

### DIFF
--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -375,6 +375,7 @@ interface VendettaObject {
 interface VendettaPluginObject {
     manifest: PluginManifest;
     storage: Indexable<any>;
+    logger: Logger;
 }
 
 declare global {

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -1,7 +1,10 @@
 import { Indexable, PluginManifest, Plugin } from "@types";
 import { awaitSyncWrapper, createMMKVBackend, createStorage, wrapSync } from "@lib/storage";
+import { findByProps } from "@metro/filters";
 import safeFetch from "@utils/safeFetch";
 import logger from "@lib/logger";
+
+const logModule = findByProps("setLogFn").default;
 
 type EvaledPlugin = {
     onLoad?(): void;
@@ -60,6 +63,7 @@ export async function evalPlugin(plugin: Plugin) {
             manifest: plugin.manifest,
             // Wrapping this with wrapSync is NOT an option.
             storage: await createStorage<Indexable<any>>(createMMKVBackend(plugin.id)),
+            logger: new logModule(plugin.manifest.name),
         }
     };
     const pluginString = `vendetta=>{return ${plugin.js}}\n//# sourceURL=${plugin.id}`;


### PR DESCRIPTION
This PR adds a plugin-specific logger to `vendetta.plugin` for plugins to use for logging. This makes it easier to find logs from a specific plugin, and looks better.
This PR does not break existing plugins that use `vendetta.logger`, although they should move to this considering it's not much work and the benefits stated above.

![IMG_7189](https://user-images.githubusercontent.com/30497388/219566599-6c61838c-a620-4c58-a333-83171be8560d.jpeg)

Let me know if logModule should be moved to common, although plugins shouldn't really need to make more loggers considering they're given one.