### PR TITLE
[Themes] Overhaul themes data process

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "devDependencies": {
         "@react-native-clipboard/clipboard": "1.10.0",
         "@swc/core": "^1.3.35",
+        "@types/chroma-js": "^2.4.0",
         "@types/react": "18.0.27",
         "@types/react-native": "0.70.6",
         "esbuild": "^0.17.11",

--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -3,6 +3,7 @@ import _React from "react";
 import _RN from "react-native";
 import _Clipboard from "@react-native-clipboard/clipboard";
 import _moment from "moment";
+import _chroma from "chroma-js";
 
 type MetroModules = { [id: number]: any };
 
@@ -361,6 +362,7 @@ interface VendettaObject {
             React: typeof _React;
             ReactNative: typeof _RN;
             moment: typeof _moment;
+            chroma: typeof _chroma;
         };
     };
     constants: {

--- a/src/lib/metro/common.ts
+++ b/src/lib/metro/common.ts
@@ -25,3 +25,6 @@ export { ReactNative } from "@lib/preinit";
 
 // Moment
 export const moment = findByProps("isMoment") as typeof import("moment");
+
+// chroma.js
+export { chroma } from "@lib/preinit";

--- a/src/lib/preinit.ts
+++ b/src/lib/preinit.ts
@@ -19,7 +19,7 @@ export const constants = basicFind("AbortCodes");
 export const color = basicFind("SemanticColor");
 
 // Export chroma.js
-export const chroma = basicFind("brewer");
+export const chroma = basicFind("brewer") as typeof import("chroma-js");
 
 // Themes
 if (window.__vendetta_loader?.features.themes) {

--- a/src/lib/preinit.ts
+++ b/src/lib/preinit.ts
@@ -18,10 +18,13 @@ export const constants = basicFind("AbortCodes");
 // Export Discord's color module
 export const color = basicFind("SemanticColor");
 
+// Export chroma.js
+export const chroma = basicFind("brewer");
+
 // Themes
 if (window.__vendetta_loader?.features.themes) {
     try {
-        initThemes(color);
+        initThemes();
     } catch (e) {
         console.error("[Vendetta] Failed to initialize themes...", e);
     }

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,9 +1,9 @@
 import { DCDFileManager, Indexable, Theme, ThemeData } from "@types";
-import { ReactNative } from "@metro/common";
+import { ReactNative, chroma } from "@metro/common";
 import { instead } from "@lib/patcher";
+import { color } from "@lib/preinit";
 import { createFileBackend, createMMKVBackend, createStorage, wrapSync, awaitSyncWrapper } from "@lib/storage";
 import { safeFetch } from "@utils";
-import { chroma, color } from "./preinit";
 
 const DCDFileManager = window.nativeModuleProxy.DCDFileManager as DCDFileManager;
 export const themes = wrapSync(createStorage<Indexable<Theme>>(createMMKVBackend("VENDETTA_THEMES")));


### PR DESCRIPTION
- new common module export, [chroma.js](https://github.com/gka/chroma.js) and make use of it
- replace Android's specific alpha color keys (discord why)
- rewrite `resolveSemanticColor` patch, believed to be more efficient and accurately "mimicking" the original function