### PR TITLE
[Metro > Common] Fix constants find

### DIFF
--- a/src/lib/metro/common.ts
+++ b/src/lib/metro/common.ts
@@ -2,7 +2,7 @@ import { DiscordStyleSheet } from "@types";
 import { find, findByProps } from "@metro/filters";
 
 // Discord
-export const constants = findByProps("API_HOST");
+export const constants = findByProps("Fonts", "Permissions");
 export const channels = findByProps("getVoiceChannelId");
 export const i18n = findByProps("Messages");
 export const url = findByProps("openURL", "openDeeplink");


### PR DESCRIPTION
Discord renamed API_HOST to APP_URL_PREFIX in iOS build 44564, breaking our constants find. Instead, we should use Fonts and Permissions because those shouldn't ever be removed from constants.. right?