### PR TITLE
Fix install sheets

### DIFF
--- a/src/ui/quickInstall/forumPost.tsx
+++ b/src/ui/quickInstall/forumPost.tsx
@@ -9,9 +9,7 @@ import { showToast } from "@ui/toasts";
 import { Forms } from "@ui/components";
 
 const ForumPostLongPressActionSheet = findByName("ForumPostLongPressActionSheet", false);
-const { FormRow } = Forms;
-// Discord uses this Icon in action sheets. FormRow.Icon is too dark.
-const Icon = findByName("Icon");
+const { FormRow, FormIcon } = Forms;
 
 const { useFirstForumPostMessage } = findByProps("useFirstForumPostMessage");
 const { hideActionSheet } = findByProps("openLazy", "hideActionSheet");
@@ -51,7 +49,7 @@ export default () => after("default", ForumPostLongPressActionSheet, ([{ thread 
 
     actions.unshift(<ActionsSection key="install">
         <FormRow
-            leading={<Icon source={getAssetIDByName("ic_download_24px")} />}
+            leading={<FormIcon style={{ opacity: 1 }} source={getAssetIDByName("ic_download_24px")} />}
             label={`Install ${postType}`}
             onPress={() =>
                 (postType === "Plugin" ? installPlugin : installTheme)(url).then(() => {


### PR DESCRIPTION
Issue: They've stripped Icon component's name, `findByName("Icon")` would fail