### PR TITLE
[CI] Purge CDN cache at every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,8 @@ jobs:
                   git add .
                   git commit -m "Build $GITHUB_SHA" || exit 0
                   git push
+
+            - name: Purge CDN cache
+              run: |
+                  curl https://purge.jsdelivr.net/gh/vendetta-mod/builds
+                  


### PR DESCRIPTION
> https://github.com/jsdelivr/jsdelivr/issues/18039#issuecomment-845833537

why? there is instruction on discord server (/tag get name:vendetta_blocked)

There is [`gacts/purge-jsdelivr-cache`](https://github.com/gacts/purge-jsdelivr-cache/) action package, but I don't want to rely on simply sending it to api