### PR TITLE
[TS] Use Symbol.for for emitterSymbol & syncAwaitSymbol

### DIFF
--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -480,6 +480,8 @@ interface VendettaObject {
         registerCommand: (command: ApplicationCommand) => () => void;
     };
     storage: {
+        emitterSymbol: Symbol,
+        syncAwaitSymbol: Symbol,
         createProxy: <T>(target: T) => { proxy: T, emitter: Emitter };
         useProxy: <T>(storage: T) => T;
         createStorage: <T>(backend: StorageBackend) => Promise<Awaited<T>>;

--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -480,8 +480,6 @@ interface VendettaObject {
         registerCommand: (command: ApplicationCommand) => () => void;
     };
     storage: {
-        emitterSymbol: Symbol,
-        syncAwaitSymbol: Symbol,
         createProxy: <T>(target: T) => { proxy: T, emitter: Emitter };
         useProxy: <T>(storage: T) => T;
         createStorage: <T>(backend: StorageBackend) => Promise<Awaited<T>>;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,8 +1,8 @@
 import { Emitter, StorageBackend } from "@types";
 import createEmitter from "@lib/emitter";
 
-const emitterSymbol = Symbol("emitter accessor");
-const syncAwaitSymbol = Symbol("wrapSync promise accessor");
+export const emitterSymbol = Symbol("emitter accessor");
+export const syncAwaitSymbol = Symbol("wrapSync promise accessor");
 
 export function createProxy(target: any = {}): { proxy: any; emitter: Emitter } {
     const emitter = createEmitter();

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,8 +1,8 @@
 import { Emitter, StorageBackend } from "@types";
 import createEmitter from "@lib/emitter";
 
-export const emitterSymbol = Symbol("emitter accessor");
-export const syncAwaitSymbol = Symbol("wrapSync promise accessor");
+const emitterSymbol = Symbol.for("emitter accessor");
+const syncAwaitSymbol = Symbol.for("wrapSync promise accessor");
 
 export function createProxy(target: any = {}): { proxy: any; emitter: Emitter } {
     const emitter = createEmitter();

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,8 +1,8 @@
 import { Emitter, StorageBackend } from "@types";
 import createEmitter from "@lib/emitter";
 
-const emitterSymbol = Symbol.for("emitter accessor");
-const syncAwaitSymbol = Symbol.for("wrapSync promise accessor");
+const emitterSymbol = Symbol.for("vendetta.storage.emitter");
+const syncAwaitSymbol = Symbol.for("vendetta.storage.accessor");
 
 export function createProxy(target: any = {}): { proxy: any; emitter: Emitter } {
     const emitter = createEmitter();


### PR DESCRIPTION
Uses Symbol.for for emitterSymbol (and syncAwaitSymbol, for consistency)

Allows plugin devs to listen for changes in storage objects outside of React elements
Example:

```ts
import { plugins } from "@vendetta/plugins";
import { showToast } from "@vendetta/ui/toasts";

let oldPlugins;
const handler = () => {
   if (oldPlugins)
      for (const plugin of Object.keys(plugins))) {
         const oldPlugin = oldPlugins[plugin], newPlugin = plugins[plugin];
         if (oldPlugin && newPlugin.enabled !== oldPlugin.enabled)
            showToast(`${newPlugin.name} is now ${newPlugin.enabled ? "enabled" : "disabled"}`);
      }
   oldPlugins = plugins;
}

const emitterSymbol = Symbol.for("vendetta.storage.emitter");
const emitter = plugins[emitterSymbol] as Emitter;
emitter.on("SET", handler);
emitter.on("DEL", handler);
```

I mainly want to use this for cloud sync and plugin browser lol