### PR TITLE
Fix You tab on recent versions

### DIFF
--- a/src/lib/preinit.ts
+++ b/src/lib/preinit.ts
@@ -1,19 +1,39 @@
 import { initThemes } from "@lib/themes";
+import { instead } from "spitroast";
 
 // Hoist required modules
 // This used to be in filters.ts, but things became convoluted
 
-// Early find logic
-const basicFind = (prop: string) => Object.values(window.modules).find(m => m?.publicModule.exports?.[prop])?.publicModule?.exports;
+const basicFind = (filter: (m: any) => any | string) => {
+    for (const key in window.modules) {
+        const exp = window.modules[key]?.publicModule.exports;
+        if (exp && filter(exp)) return exp;
+    }
+}
+
+const requireNativeComponent = basicFind(m => m?.default?.name === "requireNativeComponent");
+
+if (requireNativeComponent) {
+    // > "Tried to register two views with the same name DCDVisualEffectView"
+    // This serves as a workaround for the crashing You tab on Android starting from version 192.x
+    // How? We simply ignore it.
+    instead("default", requireNativeComponent, (args, orig) => {
+        try {
+            return orig(...args);
+        } catch {
+            return () => null;
+        }
+    })
+}
 
 // Hoist React on window
-window.React = basicFind("createElement") as typeof import("react");
+window.React = basicFind(m => m.createElement) as typeof import("react");
 
 // Export ReactNative
-export const ReactNative = basicFind("AppRegistry") as typeof import("react-native");
+export const ReactNative = basicFind(m => m.AppRegistry) as typeof import("react-native");
 
 // Export chroma.js
-export const chroma = basicFind("brewer") as typeof import("chroma-js");
+export const chroma = basicFind(m => m.brewer) as typeof import("chroma-js");
 
 // Themes
 if (window.__vendetta_loader?.features.themes) {

--- a/src/ui/settings/data.tsx
+++ b/src/ui/settings/data.tsx
@@ -111,6 +111,7 @@ export const getYouData = () => {
     return {
         getLayout: () => ({
             title: "Vendetta",
+            label: "Vendetta",
             // We can't use our keyMap function here since `settings` is an array not an object
             settings: getRenderableScreens(true).map(s => s.key)
         }),
@@ -124,6 +125,7 @@ export const getYouData = () => {
 
             return {
                 type: "route",
+                title: () => s.title,
                 icon: s.icon ? getAssetIDByName(s.icon) : null,
                 screen: {
                     // TODO: This is bad, we should not re-convert the key casing


### PR DESCRIPTION
- Workaround for crash caused by double `requireNativeComponent` registration (force loading modules side effect)
- You tab patch support for newer versions
- Support for older versions is implemented, however, untested